### PR TITLE
Turn "forall" into a reserved keyword

### DIFF
--- a/chapters/02-lexical-structure.typ
+++ b/chapters/02-lexical-structure.typ
@@ -185,7 +185,7 @@ comment in that code will interfere with the nested comments.
   $italic("conid")$, $->$, $nonterminal("large") {nonterminal("small") | nonterminal("large") | nonterminal("digit") | terminal("'") med }$,
   // reservedid
   $italic("reservedid")$, $->$, $terminal("case") | terminal("class") | terminal("data") | terminal("default") | terminal("deriving") | terminal("do") | terminal("else")$,
-  [], $|$, $terminal("foreign") | terminal("if") | terminal("import") | terminal("in") | terminal("infix") | terminal("infixl")$,
+  [], $|$, $terminal("forall") | terminal("foreign") | terminal("if") | terminal("import") | terminal("in") | terminal("infix") | terminal("infixl")$,
   [], $|$, $terminal("infixr") | terminal("instance") | terminal("let") | terminal("module") | terminal("newtype") | terminal("of")$,
   [], $|$, $terminal("then") | terminal("type") | terminal("where") | terminal("_")$,
 )

--- a/chapters/10-syntax-reference.typ
+++ b/chapters/10-syntax-reference.typ
@@ -131,7 +131,7 @@ lambda abstractions extend to the right as far as possible.
   $nonterminaldef("conid")$, $->$, $nonterminal("large") {nonterminal("small") | nonterminal("large") | nonterminal("digit") | terminal("'") med }$,
   // reservedid
   $nonterminaldef("reservedid")$, $->$, $terminal("case") | terminal("class") | terminal("data") | terminal("default") | terminal("deriving") | terminal("do") | terminal("else")$,
-  [], $|$, $terminal("foreign") | terminal("if") | terminal("import") | terminal("in") | terminal("infix") | terminal("infixl")$,
+  [], $|$, $terminal("forall") | terminal("foreign") | terminal("if") | terminal("import") | terminal("in") | terminal("infix") | terminal("infixl")$,
   [], $|$, $terminal("infixr") | terminal("instance") | terminal("let") | terminal("module") | terminal("newtype") | terminal("of")$,
   [], $|$, $terminal("then") | terminal("type") | terminal("where") | terminal("_")$,
 )

--- a/other/preface_revised.typ
+++ b/other/preface_revised.typ
@@ -11,3 +11,7 @@ These standard libraries are now available in the form of a zero-dependency Hask
 
 
 #heading(level: 2, numbering: none)[Changes to the  Report]
+
+#heading(level: 3, numbering: none)[Forall as a keyword]
+
+The definition of the nonterminal $nonterminal("reservedid")$ has been changed to also include the terminal $terminal("forall")$ as a reserved identifier.


### PR DESCRIPTION
Fixes #2 by extending the nonterminal `<reservedid>` to also include the terminal `forall`.