### PR TITLE
Remove orphans instances from stdlib

### DIFF
--- a/stdlib/haskell2010-base.cabal
+++ b/stdlib/haskell2010-base.cabal
@@ -61,7 +61,7 @@ library
       Text.Read
       Text.Show
     default-extensions: NoImplicitPrelude
-    ghc-options: -Wno-missing-methods
+    ghc-options: -Wno-missing-methods -Werror=orphans
     build-depends:
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/stdlib/src/Data/Enum.hs
+++ b/stdlib/src/Data/Enum.hs
@@ -4,6 +4,7 @@ module Data.Enum where
 
 import Data.Int
 import Data.Word
+import Prim
 
 class Enum a where
   succ, pred :: a -> a
@@ -13,6 +14,8 @@ class Enum a where
   enumFromThen :: a -> a -> [a]
   enumFromTo :: a -> a -> [a]
   enumFromThenTo :: a -> a -> a -> [a]
+
+instance Enum Char
 
 instance Enum Word
 
@@ -24,6 +27,8 @@ instance Enum Word32
 
 instance Enum Word64
 
+instance Enum Integer
+
 instance Enum Int
 
 instance Enum Int8
@@ -34,9 +39,15 @@ instance Enum Int32
 
 instance Enum Int64
 
+instance Enum Float
+
+instance Enum Double
+
 class Bounded a where
   minBound :: a
   maxBound :: a
+
+instance Bounded Char
 
 instance Bounded Word
 

--- a/stdlib/src/Data/Eq.hs
+++ b/stdlib/src/Data/Eq.hs
@@ -39,6 +39,10 @@ instance Eq Word32
 
 instance Eq Word64
 
+instance Eq Float
+
+instance Eq Double
+
 -- 2
 instance (Eq a, Eq b) => Eq (a, b)
 

--- a/stdlib/src/Data/Ord.hs
+++ b/stdlib/src/Data/Ord.hs
@@ -47,6 +47,10 @@ instance Ord Word32
 
 instance Ord Word64
 
+instance Ord Float
+
+instance Ord Double
+
 -- 2
 instance (Ord a, Ord b) => Ord (a, b)
 

--- a/stdlib/src/NumHierarchy.hs
+++ b/stdlib/src/NumHierarchy.hs
@@ -77,6 +77,8 @@ class (Eq a, Show a) => Num a where
   abs, signum :: a -> a
   fromInteger :: Integer -> a
 
+instance Num Integer
+
 instance Num Int
 
 instance Num Int8
@@ -97,6 +99,10 @@ instance Num Word32
 
 instance Num Word64
 
+instance Num Float
+
+instance Num Double
+
 class (Num a, Ord a) => Real a where
   toRational :: a -> Rational
 
@@ -110,6 +116,8 @@ instance Real Word32
 
 instance Real Word64
 
+instance Real Integer
+
 instance Real Int
 
 instance Real Int8
@@ -119,6 +127,10 @@ instance Real Int16
 instance Real Int32
 
 instance Real Int64
+
+instance Real Float
+
+instance Real Double
 
 class (Real a, Enum a) => Integral a where
   quot, rem :: a -> a -> a
@@ -135,6 +147,8 @@ instance Integral Word16
 instance Integral Word32
 
 instance Integral Word64
+
+instance Integral Integer
 
 instance Integral Int
 
@@ -153,6 +167,10 @@ class (Num a) => Fractional a where
   recip :: a -> a
   fromRational :: Rational -> a
 
+instance Fractional Float
+
+instance Fractional Double
+
 infixr 8 ⋆⋆
 
 class (Fractional a) => Floating a where
@@ -164,10 +182,18 @@ class (Fractional a) => Floating a where
   sinh, cosh, tanh :: a -> a
   asinh, acosh, atanh :: a -> a
 
+instance Floating Float
+
+instance Floating Double
+
 class (Real a, Fractional a) => RealFrac a where
   properFraction :: (Integral b) => a -> (b, a)
   truncate, round :: (Integral b) => a -> b
   ceiling, floor :: (Integral b) => a -> b
+
+instance RealFrac Float
+
+instance RealFrac Double
 
 class (RealFrac a, Floating a) => RealFloat a where
   floatRadix :: a -> Integer
@@ -184,3 +210,7 @@ class (RealFrac a, Floating a) => RealFloat a where
   isNegativeZero :: a -> Bool
   isIEEE :: a -> Bool
   atan2 :: a -> a -> a
+
+instance RealFloat Float
+
+instance RealFloat Double

--- a/stdlib/src/Prelude.hs
+++ b/stdlib/src/Prelude.hs
@@ -173,56 +173,11 @@ f $! x = x `seq` f x
 
 -- Character type
 
-instance Enum Char
-
-instance Bounded Char
-
 -- Ordering type
 
 -- Standard numeric types.  The data declarations for these types cannot
 -- be expressed directly in Haskell since the constructor lists would be
 -- far too large.
-
-
-instance Num Integer
-
-instance Real Integer
-
-instance Integral Integer
-
-instance Enum Integer
-
-instance Eq Float
-
-instance Ord Float
-
-instance Num Float
-
-instance Real Float
-
-instance Fractional Float
-
-instance Floating Float
-
-instance RealFrac Float
-
-instance RealFloat Float
-
-instance Eq Double
-
-instance Ord Double
-
-instance Num Double
-
-instance Real Double
-
-instance Fractional Double
-
-instance Floating Double
-
-instance RealFrac Double
-
-instance RealFloat Double
 
 -- The Enum instances for Floats and Doubles are slightly unusual.
 -- The ‘toEnum' function truncates numbers to Int.  The definitions
@@ -230,10 +185,6 @@ instance RealFloat Double
 -- series: [0,0.1 .. 0.95].  However, roundoff errors make these somewhat
 -- dubious.  This example may have either 10 or 11 elements, depending on
 -- how 0.1 is represented.
-
-instance Enum Float
-
-instance Enum Double
 
 numericEnumFrom :: (Fractional a) => a -> [a]
 numericEnumFrom = numericEnumFrom


### PR DESCRIPTION
This removes the orphans from the Prelude and adds `-Werror=orphans` to ensure no further orphans are added.