### PR TITLE
Feature/GitHub pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+# Only one deployment at a time; do not cancel a running one, so that a
+# deployment always finishes in a consistent state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: typst-community/setup-typst@40d32bb6ccb235bd7f5164cb47cfd40a5ea3a314 # v5.2.0
+      # The bundle has to be built first: it creates the _site directory, and
+      # typst does not create the parent directory of the PDF output on its own.
+      - run: typst compile --format bundle --features bundle --features html haskell-2010-revised-html.typ _site
+      - run: typst compile haskell-2010-revised.typ _site/haskell-2010-revised.pdf
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy site
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/github-pages
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,15 +22,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: typst-community/setup-typst@40d32bb6ccb235bd7f5164cb47cfd40a5ea3a314 # v5.2.0
+      - uses: typst-community/setup-typst@v5
       # The bundle has to be built first: it creates the _site directory, and
       # typst does not create the parent directory of the PDF output on its own.
       - run: typst compile --format bundle --features bundle --features html haskell-2010-revised-html.typ _site
       - run: typst compile haskell-2010-revised.typ _site/haskell-2010-revised.pdf
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: _site
 
@@ -47,4 +47,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/github-pages
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Hello! I'm Ryosuke Tomita, from Japan.

I'm a big fan of Haskell, so I'm so happy to publish revised-report.

## About

This PR adds a workflow that publishes the report to GitHub Pages on every push to `main`.

I tested it on my fork and it works well:

- https://ryosukedtomita.github.io/haskell-2010-revised-report/

---

## Notes for maintainers

The deployment will fail until GitHub Pages is enabled on this repository:
**Settings → Pages → Build and deployment → Source → GitHub Actions**.

Also, the `github-pages` environment only allows deployments from the default
branch by default. If you would like to test this from a branch before merging,
add it under **Settings → Environments → github-pages → Deployment branches and
tags → Add deployment branch or tag rule**.