### PR TITLE
Fix html output

### DIFF
--- a/chapters/02-lexical-structure.typ
+++ b/chapters/02-lexical-structure.typ
@@ -290,25 +290,24 @@ Since a qualified name is a lexeme, no spaces are
 allowed between the qualifier and the name.
 Sample lexical analyses are shown below.
 
-#align(center,
-  table(
-    columns: 2,
-    align: (left, left),
-    stroke: none,
-    table.vline(x: 0),
-    table.vline(x: 1),
-    table.vline(x: 2),
-    table.hline(),
-    table.header([This], [Lexes as this]),
-    table.hline(),
-    [`f.g`],[`f . g` (three tokens)],
-    [`F.g`],[`F.g` (qualified '`g`')],
-    [`f..`],[`f ..` (two tokens)],
-    [`F..`],[`F..` (qualified '`.`')],
-    [`F.`],[`F .` (two tokens)],
-    table.hline(),
-  )
+#table(
+  columns: 2,
+  align: (left, left),
+  stroke: none,
+  table.vline(x: 0),
+  table.vline(x: 1),
+  table.vline(x: 2),
+  table.hline(),
+  table.header([This], [Lexes as this]),
+  table.hline(),
+  [`f.g`],[`f . g` (three tokens)],
+  [`F.g`],[`F.g` (qualified '`g`')],
+  [`f..`],[`f ..` (two tokens)],
+  [`F..`],[`F..` (qualified '`.`')],
+  [`F.`],[`F .` (two tokens)],
+  table.hline(),
 )
+
 
 The qualifier does not change the syntactic treatment of a name;
 for example, `Prelude.+` is an infix operator with the same fixity as the

--- a/chapters/03-expressions.typ
+++ b/chapters/03-expressions.typ
@@ -65,26 +65,23 @@ The ambiguity is resolved by the meta-rule that each of these constructs extends
 
 Sample parses are shown below.
 
-#align(center,
-  table(
-    columns: 2,
-    align: (left, left),
-    stroke: none,
-    table.vline(x: 0),
-    table.vline(x: 1),
-    table.vline(x: 2),
-    table.hline(),
-    table.header([This], [Parses as]),
-    table.hline(),
-    [`f x + g y`],[`(f x) + (g y)`],
-    [`- f x + y`],[`(- (f x)) + y`],
-    [`let {...} in x + y`],[`let {...} in (x + y)`],
-    [`z + let {...} in x + y`],[`z + (let {...} in (x + y))`],
-    [`f x y :: Int`],[`(f x y) :: Int`],
-    [`\ x -> a+b :: Int`],[`\x -> ((a+b) :: Int)`],
-    table.hline(),
-  )
-
+#table(
+  columns: 2,
+  align: (left, left),
+  stroke: none,
+  table.vline(x: 0),
+  table.vline(x: 1),
+  table.vline(x: 2),
+  table.hline(),
+  table.header([This], [Parses as]),
+  table.hline(),
+  [`f x + g y`],[`(f x) + (g y)`],
+  [`- f x + y`],[`(- (f x)) + y`],
+  [`let {...} in x + y`],[`let {...} in (x + y)`],
+  [`z + let {...} in x + y`],[`z + (let {...} in (x + y))`],
+  [`f x y :: Int`],[`(f x y) :: Int`],
+  [`\ x -> a+b :: Int`],[`\x -> ((a+b) :: Int)`],
+  table.hline(),
 )
 
 For the sake of clarity, the rest of this section will assume that expressions involving infix operators have been resolved according to the fixities of the operators.
@@ -443,17 +440,16 @@ The _arithmetic sequence_ $[e_1, e_2 .. e_3]$ denotes a list of values of type $
 
 #translation-box([
   Arithmetic sequences satisfy these identities:
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      [`[` $e_1$ `..]`], $=$, [`enumFrom` $e_1$],
-      [`[` $e_1$, $e_2$ `..]`], $=$, [`enumFromThen` $e_1$ $e_2$],
-      [`[` $e_1$ `..` $e_2$ `]`], $=$, [`enumFromTo` $e_1$ $e_2$],
-      [`[` $e_1$, $e_2$ `..` $e_3$ `]`], $=$, [`enumFromThenTo` $e_1$ $e_2$ $e_3$],
-    )
-  ]
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    [`[` $e_1$ `..]`], $=$, [`enumFrom` $e_1$],
+    [`[` $e_1$, $e_2$ `..]`], $=$, [`enumFromThen` $e_1$ $e_2$],
+    [`[` $e_1$ `..` $e_2$ `]`], $=$, [`enumFromTo` $e_1$ $e_2$],
+    [`[` $e_1$, $e_2$ `..` $e_3$ `]`], $=$, [`enumFromThenTo` $e_1$ $e_2$ $e_3$],
+  )
+
   where `enumFrom`, `enumFromThen`, `enumFromTo`, and `enumFromThenTo` are class methods in the class `Enum` as defined in the Prelude (see @fig:standard-classes).
 ])
 
@@ -502,20 +498,19 @@ $
 $
 #translation-box([
   List comprehensions satisfy these identities, which may be used as a translation into the kernel:
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      $[e | mono("True")]$,$=$, $[e]$,
-      $[e | q]$,$=$,$[e | q, mono("True")]$,
-      $[e | b, Q]$, $=$, $mono("if") b mono("then") [e, Q] mono("else") []$,
-      $[e | p mono("<-") l, Q]$, $=$, $mono("let ok") = [e | Q]$,
-      $$, $$, $mono("      ok") \_ = []$,
-      $$, $$, $mono("in concatMap ok") l$,
-      $[e | mono("let") italic("decls"), Q]$, $=$, $mono("let") italic("decls") mono("in") [e | Q]$
-    )
-  ]
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    $[e | mono("True")]$,$=$, $[e]$,
+    $[e | q]$,$=$,$[e | q, mono("True")]$,
+    $[e | b, Q]$, $=$, $mono("if") b mono("then") [e, Q] mono("else") []$,
+    $[e | p mono("<-") l, Q]$, $=$, $mono("let ok") = [e | Q]$,
+    $$, $$, $mono("      ok") \_ = []$,
+    $$, $$, $mono("in concatMap ok") l$,
+    $[e | mono("let") italic("decls"), Q]$, $=$, $mono("let") italic("decls") mono("in") [e | Q]$
+  )
+
   where $e$ ranges over expressions, $p$ over
   patterns, $l$ over list-valued expressions, $b$ over
   boolean expressions, $italic("decls")$ over declaration lists, $q$ over qualifiers, and $Q$ over sequences of qualifiers.  `ok` is a fresh variable.
@@ -557,24 +552,23 @@ does not cause an execution-time error until `x` or `y` is evaluated.
   respectively, using the translation in
   @subsec:function-and-pattern-bindings.  Once done, these identities
   hold, which may be used as a translation into the kernel:
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      $mono("let") { p_1 = e_1 ; dots ; p_n = e_n} mono("in") e_0$, $=$, $mono("let")(~p_1, dots,~p_n) = (e_1, dots, e_n) mono("in") e_0$,
-      $mono("let") p = e_1 mono("in") e_0$, $=$, $mono("case") e_1 mono("of") ~p mono("->") e_0$,
-      $$, $$, [where no variable in $p$ appears free in $e_1$],
-      $mono("let") p = e_1 mono("in") e_0$, $=$, $mono("let") p = mono("fix") (\\ ~p mono("->") e_1) mono("in") e_0$
-    )
-  ]
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    $mono("let") { p_1 = e_1 ; dots ; p_n = e_n} mono("in") e_0$, $=$, $mono("let")(~p_1, dots,~p_n) = (e_1, dots, e_n) mono("in") e_0$,
+    $mono("let") p = e_1 mono("in") e_0$, $=$, $mono("case") e_1 mono("of") ~p mono("->") e_0$,
+    $$, $$, [where no variable in $p$ appears free in $e_1$],
+    $mono("let") p = e_1 mono("in") e_0$, $=$, $mono("let") p = mono("fix") (\\ ~p mono("->") e_1) mono("in") e_0$
+  )
+
   where `fix` is the least fixpoint operator.  Note the use of the irrefutable patterns `~p`.
   This translation
   does not preserve the static semantics because the use of `case` precludes a fully polymorphic typing of the bound variables.
   The static semantics of the bindings in a `let` expression are described in
   @subsec:function-and-pattern-bindings.
 ])
- 
+
 == Case Expressions <sec:case>
 
 #table(
@@ -705,19 +699,18 @@ to be written in a more traditional way as:
 #translation-box([
   Do expressions satisfy these identities, which may be
   used as a translation into the kernel, after eliminating empty $italic("stmts")$:
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      $mono("do") {e}$, $=$, $e$,
-      $mono("do") {e ; italic("stmts")}$, $=$, $e mono(">>") mono("do") {italic("stmts")}$,
-      $mono("do") {p mono("<-") e; italic("stmts")}$, $=$,$mono("let ok") p = mono("do") { italic("stmts")}$,
-      $$,$$,$mono("      ok") \_ = mono("fail \"...\"")$,
-      $$,$$,$mono("in") e mono(">>=") mono("ok")$,
-      $mono("do") {mono("let") italic("decls"); italic("stmts")}$, $=$,$mono("let") italic("decls") mono("in do") { italic("stmts")}$
-    )
-  ]
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    $mono("do") {e}$, $=$, $e$,
+    $mono("do") {e ; italic("stmts")}$, $=$, $e mono(">>") mono("do") {italic("stmts")}$,
+    $mono("do") {p mono("<-") e; italic("stmts")}$, $=$,$mono("let ok") p = mono("do") { italic("stmts")}$,
+    $$,$$,$mono("      ok") \_ = mono("fail \"...\"")$,
+    $$,$$,$mono("in") e mono(">>=") mono("ok")$,
+    $mono("do") {mono("let") italic("decls"); italic("stmts")}$, $=$,$mono("let") italic("decls") mono("in do") { italic("stmts")}$
+  )
+
   The ellipsis "`...`" stands for a compiler-generated error message,
   passed to `fail`, preferably giving some indication of the location
   of the pattern-match failure;
@@ -785,34 +778,32 @@ cannot be confused with ordinary variables.
   $italic("fbind")$, $->$, $nonterminal("qvar") terminal("=") nonterminal("exp")$,[],
 )
 
-A constructor with labeled fields may be used to construct a value 
+A constructor with labeled fields may be used to construct a value
 in which the components are specified by name rather than by position.
 Unlike the braces used in declaration lists, these are not subject to
-layout; the `{` and `}` characters must be explicit. 
+layout; the `{` and `}` characters must be explicit.
 (This is also true of field updates and field patterns.)
 Construction using field labels is subject to the following constraints:
 
-- Only field labels declared with the specified constructor may be mentioned. 
+- Only field labels declared with the specified constructor may be mentioned.
 - A field label may not be mentioned more than once.
 - Fields not mentioned are initialized to $bot$.
 - A compile-time error occurs when any strict fields (fields
   whose declared types are prefixed by `!`) are omitted during
   construction.  Strict fields are discused in @sec:datatype-decls.
 
-The expression `F {}`, where `F` is a data constructor, is legal 
-_whether or not `F` was declared with record syntax_ (provided `F` has no strict fields --- see the fourth bullet above); 
+The expression `F {}`, where `F` is a data constructor, is legal
+_whether or not `F` was declared with record syntax_ (provided `F` has no strict fields --- see the fourth bullet above);
 it denotes $F bot_1 dots bot_n$, where $n$ is the arity of `F`.
 
 #translation-box([
   In the binding $f = v$, the field $f$ labels $v$.
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      $C { italic("bs") }$, $=$, $C (italic("pick")^C_1 italic("bs") mono("undefined")) dots (italic("pick")^C_k italic("bs") mono("undefined"))$,
-    )
-  ]
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    $C { italic("bs") }$, $=$, $C (italic("pick")^C_1 italic("bs") mono("undefined")) dots (italic("pick")^C_k italic("bs") mono("undefined"))$,
+  )
   where $k$ is the arity of $C$.
 
   The auxiliary function $italic("pick")^C_i italic("bs") d$ is defined as follows:
@@ -834,7 +825,7 @@ it denotes $F bot_1 dots bot_n$, where $n$ is the arity of `F`.
 
 Values belonging to a datatype with field labels may be
 non-destructively updated.  This creates a new value in which the
-specified field values replace those in the existing value.  
+specified field values replace those in the existing value.
 Updates are restricted in the following ways:
 
 - All labels must be taken from the same datatype.
@@ -846,18 +837,16 @@ Updates are restricted in the following ways:
 
 #translation-box([
   Using the prior definition of $italic("pick")$,
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      $e {italic("bs")}$, $=$, $mono("case") e mono("of")$,
-      $$, $$,$quad C_1 v_1 dots v_(k_1) mono("->") C_1 (italic("pick")^(C_1)_1 italic("bs") v_1) dots (italic("pick")^(C_1)_(k_1) italic("bs") v_(k_1))$,
-      $$, $$, $quad quad dots$,
-      $$, $$,$quad C_j v_1 dots v_(k_j) mono("->") C_j (italic("pick")^(C_j)_1 italic("bs") v_1) dots (italic("pick")^(C_j)_(k_j) italic("bs") v_(k_j))$,
-      $$, $$,$quad mono("_ -> error \"Update error\"")$
-    )
-  ]
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    $e {italic("bs")}$, $=$, $mono("case") e mono("of")$,
+    $$, $$,$quad C_1 v_1 dots v_(k_1) mono("->") C_1 (italic("pick")^(C_1)_1 italic("bs") v_1) dots (italic("pick")^(C_1)_(k_1) italic("bs") v_(k_1))$,
+    $$, $$, $quad quad dots$,
+    $$, $$,$quad C_j v_1 dots v_(k_j) mono("->") C_j (italic("pick")^(C_j)_1 italic("bs") v_1) dots (italic("pick")^(C_j)_(k_j) italic("bs") v_(k_j))$,
+    $$, $$,$quad mono("_ -> error \"Update error\"")$
+  )
   where ${ C_1, dots, C_j}$ is the set of constructors containing all labels in $italic("bs")$, and $k_i$ is the arity of $C_i$.
 
 ])
@@ -889,7 +878,7 @@ data T    = C1 {f1,f2 :: Int}
 The field `f1` is common to both constructors in T.  This
 example translates expressions using constructors in field-label
 notation into equivalent expressions using the same constructors
-without field labels. 
+without field labels.
 A compile-time error will result if no single constructor
 defines the set of field labels used in an update, such as `x {f2 = 1, f3 = 'x'}`.
 
@@ -904,18 +893,14 @@ $italic("exp")$.  As with normal type signatures (see
 @sec:type-signatures), the declared type may be more specific than
 the principal type derivable from $italic("exp")$, but it is an error to give a type that is more general than, or not comparable to, the principal type.
 
-#translation-box([
-  #align(center)[
-    #table(
-      columns: 3,
-      align: (left, center, left),
-      stroke: none,
-      $e mono("::") t$, $=$, $mono("let") { v mono("::") t; v = e} mono("in") v$
-    )
-  ]
-])
-
-
+#translation-box[
+  #table(
+    columns: 3,
+    align: (left, center, left),
+    stroke: none,
+    $e mono("::") t$, $=$, $mono("let") { v mono("::") t; v = e} mono("in") v$
+  )
+]
 
 == Pattern Matching <sec:pattern-matching>
 
@@ -1035,7 +1020,7 @@ may _diverge_ (i.e.~return $bot$).  Pattern matching proceeds from left to right
 
 Aside from the obvious static type constraints (for
 example, it is a static error to match a character against a
-boolean), the following static class constraints hold: 
+boolean), the following static class constraints hold:
 
 - An integer literal pattern can only be matched against a value in the class `Num`.
 - A floating literal pattern can only be matched against a value
@@ -1049,7 +1034,7 @@ Matching a _refutable_ pattern is strict: if the value to be matched
 is $bot$ the match diverges.
 The irrefutable patterns are as follows:
 a variable, a wildcard, $N italic("apat")$ where $N$ is a constructor
-defined by `newtype` and $italic("apat")$ is irrefutable (see @sec:datatype-renamings), 
+defined by `newtype` and $italic("apat")$ is irrefutable (see @sec:datatype-renamings),
 $italic("var")mono("@")italic("apat")$ where $italic("apat")$ is irrefutable,
 or of the form $~italic("apat")$ (whether or not $italic("apat")$ is irrefutable).
 All other patterns are _refutable_.
@@ -1114,16 +1099,16 @@ both `a` and `y` will be evaluated by `==` in the guard.
 The semantics of all pattern matching constructs other than `case`
 expressions are defined by giving identities that relate those
 constructs to `case` expressions.
-The semantics of `case` expressions themselves are in turn given as a series of identities, in @fig:simple-case-expr-1 -- @fig:simple-case-expr-3. 
-Any implementation should behave so that these identities hold; it is 
-not expected that it will use them directly, since that 
+The semantics of `case` expressions themselves are in turn given as a series of identities, in @fig:simple-case-expr-1 -- @fig:simple-case-expr-3.
+Any implementation should behave so that these identities hold; it is
+not expected that it will use them directly, since that
 would generate rather inefficient code.
 
 In @fig:simple-case-expr-1 -- @fig:simple-case-expr-3:
-$e$, $e'$ and $e_i$ are expressions; 
+$e$, $e'$ and $e_i$ are expressions;
 $g_i$ and $italic("gs")_i$ are guards and sequences of guards respectively;
-$p$ and $p_i$ are patterns; 
-$v$, $x$, and $x_i$ are variables; 
+$p$ and $p_i$ are patterns;
+$v$, $x$, and $x_i$ are variables;
 $K$ and $K'$ are algebraic datatype (`data`) constructors (including
 tuple constructors);  and $N$ is a `newtype` constructor.
 

--- a/chapters/04-declarations.typ
+++ b/chapters/04-declarations.typ
@@ -427,15 +427,14 @@ For example, the declaration
 data Eq a => Set a = NilSet | ConsSet a (Set a)
 ```
 introduces a type constructor `Set` of kind $ast -> ast$, and constructors `NilSet` and `ConsSet` with types
-#align(center)[
-  #table(
+#table(
     columns: 3,
     align: (left, center, left),
     stroke: none,
     [`NilSet`], [`::`], $forall a. mono("Set") a$,
     [`ConsSet`], [`::`], $forall a. mono("Eq") a => a -> mono("Set") a -> mono("Set") a$,
-  )
-]
+)
+
 In the example given, the overloaded
 type for `ConsSet` ensures that `ConsSet` can only be applied to values whose
 type is an instance of the class `Eq`.
@@ -1212,32 +1211,31 @@ within a `where` or `let` construct.
 
 A function binding binds a variable to a function value.  The general
 form of a function binding for variable $x$ is:
-#align(center)[
-  #table(
-    columns: 3,
-    align: (left, left, left),
-    stroke: none,
-    $x$, $p_(11) space dots space p_(1 k)$, $italic("match")_1$,
-    $dots$,$$,$$,
-    $x$, $p_(n 1) space dots space p_(n k)$, $italic("match")_n$
-  )
-]
+#table(
+  columns: 3,
+  align: (left, left, left),
+  stroke: none,
+  $x$, $p_(11) space dots space p_(1 k)$, $italic("match")_1$,
+  $dots$,$$,$$,
+  $x$, $p_(n 1) space dots space p_(n k)$, $italic("match")_n$
+)
+
 where each $p_(i j)$ is a pattern, and where each $italic("match")_i$ is of the general form:
 $
   = e_i mono("where") { space italic("decls")_i space }
 $
 or
-#align(center)[
-  #table(
-    columns: 2,
-    align: (left, left),
-    stroke: none,
-    $| italic("gs")_(i 1)$, $= e_(i 1)$,
-    $dots$, $$,
-    $| italic("gs")_(i m_i)$, $= e_(i m_i)$,
-    $$, $mono("where") { space italic("decls")_i space }$
-  )
-]
+
+#table(
+  columns: 2,
+  align: (left, left),
+  stroke: none,
+  $| italic("gs")_(i 1)$, $= e_(i 1)$,
+  $dots$, $$,
+  $| italic("gs")_(i m_i)$, $= e_(i m_i)$,
+  $$, $mono("where") { space italic("decls")_i space }$
+)
+
 and where $n >= 1$, $1 <= i <= n$, $m_i >= 1$.  The former is treated
 as shorthand for a particular case of the latter, namely:
 $
@@ -1298,36 +1296,34 @@ The _general_ form of a pattern binding is $p italic("match")$, where a
 $italic("match")$ is the same structure as for function bindings above; in other
 words, a pattern binding is:
 
-#align(center)[
-  #table(
-    columns: 2,
-    stroke: none,
-    align: (right, left),
-    $p$, $| italic("gs")_1 = e_1$,
-    $$, $| italic("gs")_2 = e_2$,
-    $$, $dots$,
-    $$, $| italic("gs")_m = e_m$,
-    $$, $mono("where") { space italic("decls") space }$
-  )
-]
+#table(
+  columns: 2,
+  stroke: none,
+  align: (right, left),
+  $p$, $| italic("gs")_1 = e_1$,
+  $$, $| italic("gs")_2 = e_2$,
+  $$, $dots$,
+  $$, $| italic("gs")_m = e_m$,
+  $$, $mono("where") { space italic("decls") space }$
+)
+
 
 #translation-box[
   The pattern binding above is semantically equivalent to this simple pattern binding:
-  #align(center)[
-    #table(
-      columns: 2,
-      align: (right, left),
-      stroke: none,
-      $p space =$, $mono("let") italic("decls") mono("in")$,
-      $$, $mono("case") () mono("of")$,
-      $$, $quad () | italic("gs")_1 -> e_1$,
-      $$, $quad quad | italic("gs")_2 -> e_2 $,
-      $$, $quad quad quad dots$,
-      $$, $quad quad | italic("gs")_m -> e_m$,
-      $$, $mono("_") -> mono("error \"Unmatched pattern\"")$
-    )
-  ]
+  #table(
+    columns: 2,
+    align: (right, left),
+    stroke: none,
+    $p space =$, $mono("let") italic("decls") mono("in")$,
+    $$, $mono("case") () mono("of")$,
+    $$, $quad () | italic("gs")_1 -> e_1$,
+    $$, $quad quad | italic("gs")_2 -> e_2 $,
+    $$, $quad quad quad dots$,
+    $$, $quad quad | italic("gs")_m -> e_m$,
+    $$, $mono("_") -> mono("error \"Unmatched pattern\"")$
+  )
 ]
+
 
 == Static Semantics of Function and Pattern Bindings
 

--- a/chapters/04-declarations.typ
+++ b/chapters/04-declarations.typ
@@ -305,8 +305,8 @@ and constructor classes, respectively, in more detail.)
 
 The Haskell type system attributes a _type_ to each
 expression in the program.  In general, a type is of the form
-$forall overline(u). italic("cx") => t$,
-where $overline(u)$ is a set of type variables $u_1, dots, u_n$.
+$forall safeoverline(u). italic("cx") => t$,
+where $safeoverline(u)$ is a set of type variables $u_1, dots, u_n$.
 In any such type, any of the universally-quantified type variables $u_i$
 that are free in $italic("cx")$ must also be free in $t$.
 Furthermore, the context $italic("cx")$ must be of the form given above in
@@ -341,16 +341,16 @@ described in @sec:default-decls).  Therefore, explicit typings (called
 _type signatures_)
 are usually optional (see @sec:expression-type-sigs and @sec:type-signatures).
 
-The type $forall overline(u).italic("cx")_1 => t_1$ _more general than_ the 
-type $forall overline(w). italic("cx")_2 => t_2$ if and only if there is 
-a substitution $S$ whose domain is $overline(u)$ such that:
+The type $forall safeoverline(u).italic("cx")_1 => t_1$ _more general than_ the 
+type $forall safeoverline(w). italic("cx")_2 => t_2$ if and only if there is 
+a substitution $S$ whose domain is $safeoverline(u)$ such that:
 
 - $t_2$ is identical to $S(t_1)$.
 - Whenever $italic("cx")_2$ holds in the class environment, $S(italic("cx")_1)$ also holds.
 
-A value of type $forall overline(u).italic("cx") => t$,
-may be instantiated at types $overline(s)$ if and only if
-the context $italic("cx")[overline(s)/overline(u)]$ holds.
+A value of type $forall safeoverline(u).italic("cx") => t$,
+may be instantiated at types $safeoverline(s)$ if and only if
+the context $italic("cx")[safeoverline(s)/safeoverline(u)]$ holds.
 For example, consider the function `double`:
 ```haskell
 double x = x + x
@@ -700,12 +700,12 @@ of declarations:
 
   The type of the top-level class method $v_i$ is:
   $
-    v_i mono("::") forall u, overline(w). (C u, italic("cx")_i) mono("=>") t_i
+    v_i mono("::") forall u, safeoverline(w). (C u, italic("cx")_i) mono("=>") t_i
   $
   The $t_i$ must mention $u$; it may mention type variables
-  $overline(w)$ other than $u$, in which case the type of $v_i$ is
-  polymorphic in both $u$ and $overline(w)$.
-  The $italic("cx")_i$ may constrain only $overline(w)$; in particular,
+  $safeoverline(w)$ other than $u$, in which case the type of $v_i$ is
+  polymorphic in both $u$ and $safeoverline(w)$.
+  The $italic("cx")_i$ may constrain only $safeoverline(w)$; in particular,
   the $italic("cx")_i$ may not constrain $u$.
   For example:
   ```haskell
@@ -940,8 +940,8 @@ in both cases, or `Bool`.  Such expressions
 are considered ill-typed, a static error.
 
 We say that an expression `e` has an _ambiguous type_
-if, in its type $forall overline(u).italic("cx") => t$, 
-there is a type variable $u$ in $overline(u)$ that occurs in $italic("cx")$ 
+if, in its type $forall safeoverline(u).italic("cx") => t$, 
+there is a type variable $u$ in $safeoverline(u)$ that occurs in $italic("cx")$ 
 but not in $t$.  Such types are invalid.
 
 For example, the earlier expression involving `show` and `read` has
@@ -1477,10 +1477,10 @@ for it to be
 ```haskell
   (g True, g 'c')
 ```
-In general, a type $forall overline(u).italic("cx") => t$
+In general, a type $forall safeoverline(u).italic("cx") => t$
 is said to be _monomorphic_
 in the type variable $a$ if $a$ is free in
-$forall overline(u).italic("cx") => t$.
+$forall safeoverline(u).italic("cx") => t$.
 
 It is worth noting that the explicit type signatures provided by Haskell
 are not powerful enough to express types that include monomorphic type

--- a/chapters/05-modules.typ
+++ b/chapters/05-modules.typ
@@ -361,8 +361,7 @@ This declaration brings into scope `f` and `A.f`.
 To clarify the above import rules, suppose the module `A` exports `x` and `y`.
 Then this table shows what names are brought into scope by the specified import statement:
 
-#align(center)[
-  #table(
+#table(
     columns: 2,
     align: (left, left),
     stroke: none,
@@ -385,8 +384,8 @@ Then this table shows what names are brought into scope by the specified import 
     [`import A as B(x)`], [`x`,`B.x`],
     [`import qualified A as B`], [`B.x`, `B.y`],
     table.hline(),
-  )
-]
+)
+
 
 In all cases, all instance declarations in scope in module `A` are imported
 (@sec:import-instances).

--- a/chapters/11-derived-instances.typ
+++ b/chapters/11-derived-instances.typ
@@ -1,3 +1,5 @@
+#import "../macros.typ" : *
+
 A _derived instance_ is an instance declaration that is generated
 automatically in conjunction with a `data` or `newtype` declaration.
 The body of a derived instance declaration is derived syntactically from
@@ -171,9 +173,10 @@ Parsing of an un-parenthesised infix operator application succeeds only
 if the precedence of the operator is greater than or equal to `d`.
 
 It should be the case that
-#align(center,
-  [`(x,"")` is an element of `(readsPrec d (showsPrec d x ""))`]
-)
+#center-box[
+  `(x,"")` is an element of `(readsPrec d (showsPrec d x ""))`
+]
+
 That is, `readsPrec` should be able to parse the string produced by `showsPrec`, and should deliver the value that `showsPrec` started with.
 
 `showList` and `readList` allow lists of objects to be represented

--- a/macros.typ
+++ b/macros.typ
@@ -39,3 +39,17 @@
      html.elem("div", attrs: (style: "text-align: center;"))[#body]
   }
 }
+
+// See https://github.com/typst/typst/issues/8509
+#let safeoverline(body) = context {
+  if target() == "paged" {
+    // Code for PDF output
+    math.overline(body)
+  } else {
+    // Code for HTML output
+    html.elem("mover", attrs: (accent: "true"))[
+      #body
+      #html.elem("mo", "_")
+    ]
+  }
+}

--- a/macros.typ
+++ b/macros.typ
@@ -29,3 +29,13 @@
   inset: 10pt,
   [*The monomorphism restriction*\ #x]
 )
+
+#let center-box(body) = context {
+  if target() == "paged" {
+     // Code for PDF output
+     align(center)[#body]
+  } else {
+    // Code for HTML output
+     html.elem("div", attrs: (style: "text-align: center;"))[#body]
+  }
+}

--- a/other/preface.typ
+++ b/other/preface.typ
@@ -1,3 +1,5 @@
+#import "../macros.typ" : *
+
 #quote(attribution: [Haskell B. Curry and Robert Feys\
 in the Preface to _Combinatory Logic_ @CurryFeys1958, May 31, 1956], block: true)[
   _Some half dozen persons have written technically on combinatory logic, and most of these,
@@ -70,7 +72,7 @@ served on the Language and Library committees, in particular, devoted
 a huge amount of time and energy to the language.  Here they are, with
 their affiliation(s) for the relevant period:
 
-#align(center)[
+#center-box[
 Arvind (MIT) \
 Lennart Augustsson (Chalmers University) \
 Dave Barton (Mitre Corp) \

--- a/other/preface.typ
+++ b/other/preface.typ
@@ -252,7 +252,10 @@ Sisal; and Turner's series of languages culminating in
 Miranda #footnote("Miranda is a trademark of Research Software Ltd."). Without these forerunners Haskell would not have
 been possible.
 
-#v(1in)
+#context {if target() == "paged" {
+  v(1in)
+  }
+}
 
 Simon Marlow \
 Cambridge, April 2010


### PR DESCRIPTION
All the content is now part of the HTML output. Previously some parts of the content were ignored in the HTML output. Introduces a slight regression into they layouting of the PDF output, but that can be fixed at a later point.

Relates to #1 