### PR TITLE
Add CSS to HTML

### DIFF
--- a/haskell-2010-revised-html.typ
+++ b/haskell-2010-revised-html.typ
@@ -64,7 +64,9 @@
       #if not toc {
          [#if prev != none {link(prev)[prev] } #link(<page:toc>)[Contents] #if next != none {link(next)[next]}]
       }
-      #body
+      #html.elem("div", attrs: (class: "main"))[
+        #body
+      ]
     ]
   ]
 ]

--- a/haskell-2010-revised-html.typ
+++ b/haskell-2010-revised-html.typ
@@ -53,13 +53,23 @@
 ]
 
 #let report-page(path: none, title: none, toc: false, prev: none, next: none, body) = document(path, title: title)[
-  #draft-banner
-  #if not toc {
-    [#if prev != none {link(prev)[prev] } #link(<page:toc>)[Contents] #if next != none {link(next)[next]}]
-  }
-  #body
+  #html.html[
+    #html.head[
+      #html.meta(charset: "utf-8")
+      #html.meta(name: "viewport", content: "width=device-width,  initial-scale=1")
+      #html.link(rel: "stylesheet", href: "styles.css")
+    ]
+    #html.body[
+      #draft-banner
+      #if not toc {
+         [#if prev != none {link(prev)[prev] } #link(<page:toc>)[Contents] #if next != none {link(next)[next]}]
+      }
+      #body
+    ]
+  ]
 ]
 
+#show footnote: none
 
 //
 // CONTENT
@@ -188,3 +198,5 @@
   #bibliography("bibliography.bib")
 ]<page:bibliography>
 
+// Copy the file `styles.css` into the bundle.
+#asset("styles.css", read("styles.css"))

--- a/macros.typ
+++ b/macros.typ
@@ -36,7 +36,7 @@
      align(center)[#body]
   } else {
     // Code for HTML output
-     html.elem("div", attrs: (style: "text-align: center;"))[#body]
+     html.elem("div", attrs: (style: "text-align: center;", class: "center-box"))[#body]
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,22 +1,4 @@
-body {
-    background-color: #FFFFFF;
-}
-blockquote {
-    width: 1000px
-}
-
-p {
-    width: 1000px
-}
-
-.center-box {
-    width: 1000px
-}
-
-math {
-    width: 1000px
-}
-
-li {
-    width: 1000px
+.main {
+    width: 1000px;
+    margin: 20px
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,3 @@
+body {
+    background-color: #FFAAFA;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,22 @@
 body {
-    background-color: #FFAAFA;
+    background-color: #FFFFFF;
+}
+blockquote {
+    width: 1000px
+}
+
+p {
+    width: 1000px
+}
+
+.center-box {
+    width: 1000px
+}
+
+math {
+    width: 1000px
+}
+
+li {
+    width: 1000px
 }


### PR DESCRIPTION
Wraps the body of the Haskell report inside a `<div class="main"> ...</div>`, and adds a minimal `styles.css` with
```css
.main {
    width: 1000px;
    margin: 20px
}
```
which is linked to in the `<head>...</head>`.

This makes the report much more readable already.
Unfortunately, footnotes are now disabled and have to be restored.

More work on #1 