### PR TITLE
Draw translation boxes in html output

### DIFF
--- a/macros.typ
+++ b/macros.typ
@@ -16,19 +16,39 @@
 }
 
 /// A box used in defining the meaning of syntactic entities by translation.
-#let translation-box(x) = box(
-  stroke: black,
-  width: 1fr,
-  inset: 10pt,
-  [*Translation:* #x]
-)
+#let translation-box(x) = context{
+  if target() == "paged" {
+    // Code for PDF output
+    box(
+      stroke: black,
+      width: 1fr,
+      inset: 10pt,
+      [*Translation:* #x]
+    )
+  } else {
+    // Code for HTML output
+    html.elem("div", attrs: (class: "translation-box"))[
+      *Translation:* #x
+    ]
+  }
+}
 
-#let monomorphism-box(x) = box(
-  stroke: black,
-  width: 1fr,
-  inset: 10pt,
-  [*The monomorphism restriction*\ #x]
-)
+#let monomorphism-box(x) = context {
+  if target() == "paged" {
+    // Code for PDF output
+    box(
+      stroke: black,
+      width: 1fr,
+      inset: 10pt,
+      [*The monomorphism restriction*\ #x]
+    )
+  } else {
+    // Code for HTML output
+    html.elem("div", attrs: (class: "monomorphism-box"))[
+      *The monomorphism restriction*\ #x
+    ]
+  }
+}
 
 #let center-box(body) = context {
   if target() == "paged" {

--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,19 @@
     width: 1000px;
     margin: 20px
 }
+
+.translation-box {
+    border-style: solid;
+    border-width: 2pt;
+    border-color: black;
+    padding: 5px;
+    margin: 5px;
+}
+
+.monomorphism-box {
+    border-style: solid;
+    border-width: 2pt;
+    border-color: black;
+    padding: 5px;
+    margin: 5px;
+}


### PR DESCRIPTION
Section 3 on expressions explains syntax by translating them into some more primitive Core syntax. In the PDF these translations have a box with a border around them. This box was missing in the HTML output.

Cp. #1 