### PR TITLE
Fix syntax reference in HTML

### DIFF
--- a/macros.typ
+++ b/macros.typ
@@ -9,10 +9,7 @@
 }
 
 #let nonterminaldef(x) = {
-  [#figure(kind: "xxx",
-         supplement: "",
-         [#text(fill: maroon, $italic(#x)$)])
-   #label(x)]
+  [$italic(#x)$#raw("")#label(x)]
 }
 
 /// A box used in defining the meaning of syntactic entities by translation.


### PR DESCRIPTION
The Syntax Reference section looked wonky in the HTML report due to the way that link targets for BNF nonterminals were implemented before. Previously I used an empty figure as the link target, but now I have replaced that by an empty code block. This looks much better in the HTML version.

Cp. #1 