### PR TITLE
Introduce proper pattern binding terminology

### DIFF
--- a/chapters/03-expressions.typ
+++ b/chapters/03-expressions.typ
@@ -548,7 +548,7 @@ does not cause an execution-time error until `x` or `y` is evaluated.
 #translation-box([
   The dynamic semantics of the expression
   $mono("let") { d_1; dots ; d_n} mono("in") e_0$
-  are captured by this translation: After removing all type signatures, each declaration $d_i$ is translated into an equation of the form $p_i = e_i$, where $p_i$ and $e_i$ are patterns and expressions
+  are captured by this translation: After removing all type signatures, each declaration $d_i$ is translated into an equation with a standalone pattern binding, $p_i = e_i$, where $p_i$ and $e_i$ are patterns and expressions
   respectively, using the translation in
   @subsec:function-and-pattern-bindings.  Once done, these identities
   hold, which may be used as a translation into the kernel:

--- a/chapters/04-declarations.typ
+++ b/chapters/04-declarations.typ
@@ -1285,8 +1285,9 @@ is not a valid pattern.
 
 ==== Pattern bindings <sec:pattern-bindings>
 
-A pattern binding binds variables to values.  A _simple_ pattern
-binding has form $p = e$.
+A pattern binding binds variables to values.  A _standalone_ pattern
+binding has form $p = e$, where $p$ is any pattern. A _simple_ pattern
+binding has form $x = e$, where $x$ is a single variable.
 The pattern $p$ is
 matched "lazily" as an irrefutable pattern, as if there were an implicit `~` in front 
 of it.  See the translation in
@@ -1309,7 +1310,7 @@ words, a pattern binding is:
 
 
 #translation-box[
-  The pattern binding above is semantically equivalent to this simple pattern binding:
+  The pattern binding above is semantically equivalent to this standalone pattern binding:
   #table(
     columns: 2,
     align: (right, left),


### PR DESCRIPTION
This fixes an issue in the original report, where "simple pattern binding" has one of two meanings:
* A pattern binding `p = e`, where `p` is a single variable
* A pattern binding `p = e`, where `p` is any pattern

The first one is used for explaining the monomorphism restriction. The second one is used for desugaring nested declarations. The original report, even confuses these two, as the monomorphism restriction section refers to the "single pattern binding" definition, but said definition defines the any pattern variant.

Since the single variable definition is the more common and likely the intended original meaning, this introduces "standalone pattern binding" to mean the second variant.