### PR TITLE
Remove datatype contexts from stdlib

### DIFF
--- a/chapters/06-predefined-types.typ
+++ b/chapters/06-predefined-types.typ
@@ -631,10 +631,10 @@ library.
     table.hline(),
     [`Integer`], [`Integral`], [Arbitrary-precision integers],
     [`Int`], [`Integral`], [Rational numbers],
-    [`(Integral a) => Ratio a`], [`RealFrac`], [Rational numbers],
+    [`Ratio a`], [`RealFrac`], [Rational numbers],
     [`Float`], [`RealFloat`], [Real floating-point, single precision],
     [`Double`], [`RealFloat`], [Real floating-point, double precision],
-    [`(RealFloat a) => Complex a`], [`Floating`], [Complex floating-point],
+    [`Complex a`], [`Floating`], [Complex floating-point],
     table.hline(),
   )
 )<fig:numeric-types>

--- a/stdlib/src/Data/Array.hs
+++ b/stdlib/src/Data/Array.hs
@@ -41,7 +41,7 @@ import Text.Read
 import Text.Show
 
 -- | The type of immutable non-strict (boxed) arrays with indices in @i@ and elements in @e@.
-data (Ix i) => Array i e = AbstractArray
+data Array i e = AbstractArray
 
 instance (Ix i, Eq e) => Eq (Array i e)
 

--- a/stdlib/src/Data/Complex.hs
+++ b/stdlib/src/Data/Complex.hs
@@ -24,7 +24,7 @@ infix 6 :+
 --
 -- For a complex number @z@, @abs z@ is a number with the magnitude of @z@, but oriented in the positive real
 -- direction, whereas @signum z@ has the phase of @z@, but unit magnitude.
-data (RealFloat a) => Complex a
+data Complex a
   = !a :+ !a -- ^ forms a complex number from its real and imaginary rectangular components.
 
 instance (RealFloat a) => Eq (Complex a)

--- a/stdlib/src/NumHierarchy.hs
+++ b/stdlib/src/NumHierarchy.hs
@@ -14,7 +14,7 @@ import Text.Show
 -- Must be defined together with the Num typeclasses
 
 -- | Rational numbers, with numerator and denominator of some @Integral@ type.
-data (Integral a) => Ratio a = AbstractRatio
+data Ratio a = AbstractRatio
 
 instance (Integral a) => Enum (Ratio a)
 


### PR DESCRIPTION
Datatype contexts are no longer used in base. This removes them.