### PR TITLE
Add Makefile to compile library report to PDF using latex backend of haddock

### DIFF
--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -1,1 +1,2 @@
 dist-newstyle/
+latex/

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -1,4 +1,17 @@
+TITLE="Haskell 2010 Revised Library Report"
+OUTDIR=latex
+
 .PHONY: latex
 latex:
-	haddock --latex -o latex --optghc=-XNoImplicitPrelude --optghc=-XHaskell2010 $$(find src/ -name '*.hs')
+	haddock --latex --prologue=prologue.txt --title=$(TITLE) -o $(OUTDIR) --optghc=-XNoImplicitPrelude --optghc=-XHaskell2010 $$(find src/ -name '*.hs')
 	cd latex/ && pdflatex main.tex
+
+pdf: latex
+	cd latex/ && pdflatex main.tex
+
+.PHONY: clean
+clean:
+	rm -rf $(OUTDIR)
+
+view: pdf
+	open $(OUTDIR)/main.pdf

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -1,0 +1,4 @@
+.PHONY: latex
+latex:
+	haddock --latex -o latex --optghc=-XNoImplicitPrelude --optghc=-XHaskell2010 $$(find src/ -name '*.hs')
+	cd latex/ && pdflatex main.tex

--- a/stdlib/prologue.txt
+++ b/stdlib/prologue.txt
@@ -1,0 +1,1 @@
+This is the library report for the revised Haskell 2010 language report.

--- a/stdlib/src/Data/Bool.hs
+++ b/stdlib/src/Data/Bool.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Data.Bool where
 
 infixr 3 &&

--- a/stdlib/src/Data/Complex.hs
+++ b/stdlib/src/Data/Complex.hs
@@ -51,7 +51,7 @@ imagPart = imagPart
 mkPolar :: (RealFloat a) => a -> a -> Complex a
 mkPolar = mkPolar
 
--- | cis t is a complex value with magnitude 1 and phase t (modulo 2⋆pi).
+-- | cis t is a complex value with magnitude 1 and phase t (modulo 2 * pi).
 cis :: (RealFloat a) => a -> Complex a
 cis = cis
 

--- a/stdlib/src/Data/Either.hs
+++ b/stdlib/src/Data/Either.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 -- |
 -- Module: Data.Either
 module Data.Either (Either (Left, Right), either) where

--- a/stdlib/src/Data/Enum.hs
+++ b/stdlib/src/Data/Enum.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 -- |
 --  Module: Data.Enum
 module Data.Enum where

--- a/stdlib/src/Data/Eq.hs
+++ b/stdlib/src/Data/Eq.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Data.Eq where
 
 import Data.Bool

--- a/stdlib/src/Data/Function.hs
+++ b/stdlib/src/Data/Function.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Data.Function
   ( id,
     const,

--- a/stdlib/src/Data/Ix.hs
+++ b/stdlib/src/Data/Ix.hs
@@ -31,7 +31,7 @@ module Data.Ix
     --          range ((l,l'),(u,u'))
     --                  = [(i,i') | i <- range (l,u), i' <- range (l',u')]
     --          index ((l,l'),(u,u')) (i,i')
-    --                  =  index (l,u) i ⋆ rangeSize (l',u') + index (l',u') i'
+    --                  =  index (l,u) i * rangeSize (l',u') + index (l',u') i'
     --          inRange ((l,l'),(u,u')) (i,i')
     --                  = inRange (l,u) i && inRange (l',u') i'
     --
@@ -45,8 +45,8 @@ module Data.Ix
     --  --                            ik <- range (lk,uk)]
     --  --
     --  --      index ((l1,l2,...,lk),(u1,u2,...,uk)) (i1,i2,...,ik) =
-    --  --        index (lk,uk) ik + rangeSize (lk,uk) ⋆ (
-    --  --         index (lk-1,uk-1) ik-1 + rangeSize (lk-1,uk-1) ⋆ (
+    --  --        index (lk,uk) ik + rangeSize (lk,uk) * (
+    --  --         index (lk-1,uk-1) ik-1 + rangeSize (lk-1,uk-1) * (
     --  --          ...
     --  --           index (l1,u1)))
     --  --

--- a/stdlib/src/Data/Ord.hs
+++ b/stdlib/src/Data/Ord.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Data.Ord where
 
 import Data.Bool

--- a/stdlib/src/Data/String.hs
+++ b/stdlib/src/Data/String.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Data.String where
 
 import Prim (Char)

--- a/stdlib/src/Data/Tuple.hs
+++ b/stdlib/src/Data/Tuple.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Data.Tuple
   ( fst,
     snd,

--- a/stdlib/src/NumHierarchy.hs
+++ b/stdlib/src/NumHierarchy.hs
@@ -171,12 +171,12 @@ instance Fractional Float
 
 instance Fractional Double
 
-infixr 8 ⋆⋆
+infixr 8 **
 
 class (Fractional a) => Floating a where
   pi :: a
   exp, log, sqrt :: a -> a
-  (⋆⋆), logBase :: a -> a -> a
+  (**), logBase :: a -> a -> a
   sin, cos, tan :: a -> a
   asin, acos, atan :: a -> a
   sinh, cosh, tanh :: a -> a

--- a/stdlib/src/NumHierarchy.hs
+++ b/stdlib/src/NumHierarchy.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module NumHierarchy where
 
 import Data.Bool

--- a/stdlib/src/Prelude.hs
+++ b/stdlib/src/Prelude.hs
@@ -38,7 +38,7 @@ module Prelude
         exp,
         log,
         sqrt,
-        (⋆⋆),
+        (**),
         logBase,
         sin,
         cos,

--- a/stdlib/src/PreludeIO.hs
+++ b/stdlib/src/PreludeIO.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module PreludeIO
   ( FilePath,
     IOError,

--- a/stdlib/src/PreludeList.hs
+++ b/stdlib/src/PreludeList.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module PreludeList
   ( map,
     (++),

--- a/stdlib/src/PreludeText.hs
+++ b/stdlib/src/PreludeText.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module PreludeText
   ( ReadS,
     ShowS,

--- a/stdlib/src/Prim.hs
+++ b/stdlib/src/Prim.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Prim (Char, Float, Double, Integer) where
 
 -- | The character type @Char@ is an enumeration whose values represent Unicode (or equivalently ISO/IEC

--- a/stdlib/src/Text/Read.hs
+++ b/stdlib/src/Text/Read.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Text.Read where
 
 import Data.Bool

--- a/stdlib/src/Text/Show.hs
+++ b/stdlib/src/Text/Show.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK hide #-}
 module Text.Show where
 
 import Data.Bool


### PR DESCRIPTION
Needed some cleanup in the `.hs` files, but I am now able to compile directly without using `cabal` or `stack`.
The result is as follows:

[main.pdf](https://github.com/user-attachments/files/31189362/main.pdf)

Cp. #18 