### PR TITLE
Remove mutually recursive modules

### DIFF
--- a/chapters/05-modules.typ
+++ b/chapters/05-modules.typ
@@ -20,7 +20,6 @@ which must be a computation of type $mono("IO") tau$ for some type $tau$
 Modules may reference other modules via explicit
 `import` declarations, each giving the name of a module to be
 imported and specifying its entities to be imported.
-Modules may be mutually recursive.
 
 Modules are used for name-space control, and are not first class values.
 A multi-module Haskell program can be converted into a single-module
@@ -53,9 +52,6 @@ af = ...
 
 bf = ...
 ```
-Because they are allowed to be mutually recursive,
-modules allow a program to be partitioned freely without regard to
-dependencies.
 
 A module name (lexeme $italic("modid")$) is a sequence of one or more
 identifiers beginning with capital letters, separated by dots, with no
@@ -219,9 +215,7 @@ import qualified C(f,g)
 g = f True
 ```
 There are no name clashes within module `A` itself, 
-but there are name clashes in the export list between `C.g` and `g`
-(assuming `C.g` and `g` are different entities -- remember, modules
-can import each other recursively), and between `module B` and `C.f`
+but there are name clashes in the export list between `C.g` and `g`, and between `module B` and `C.f`
 (assuming `B.f` and `C.f` are different entities).
 
 == Import Declarations <sec:import>
@@ -648,15 +642,13 @@ to `++` imported from `MyPrelude`.
 It is not possible, however, to hide `instance` declarations in the
 `Prelude`.  For example, one cannot define a new instance for `Show Char`.
 
-== Separate Compilation
+== Mutually Recursive Modules
 
-Depending on the Haskell implementation used, separate compilation
-of mutually recursive modules may require that imported modules contain
-additional information so that they may be referenced before they are
-compiled.  Explicit type signatures for all exported values may be
-necessary to deal with mutual recursion.  The
-precise details of separate compilation are not defined by this
-report. 
+Implementations are only required to provide support for acyclic modules.
+Implementations may provide mutually recursive module support at their own
+digression. Such support may have arbitrary requirements and limitations such
+as additional information that they may be referenced before module compilitaion
+and explicit type signatures for all exported values.
 
 == Abstract Datatypes <sec:abstract-types>
 

--- a/chapters/05-modules.typ
+++ b/chapters/05-modules.typ
@@ -644,11 +644,14 @@ It is not possible, however, to hide `instance` declarations in the
 
 == Mutually Recursive Modules
 
-Implementations are only required to provide support for acyclic modules.
-Implementations may provide mutually recursive module support at their own
-digression. Such support may have arbitrary requirements and limitations such
-as additional information that they may be referenced before module compilitaion
-and explicit type signatures for all exported values.
+Implementations are only required to provide support for acyclic module imports
+(though they must support mutually recursive declaration groups within a single module).
+
+Implementations that permit mutually recursive module imports (as a non-standard
+extension) may impose additional requirements and limitations, such
+as:
+- requiring that imported modules contain additional information so that they may be referenced before they are compiled; or
+- requiring explicit type signatures for all exported values.
 
 == Abstract Datatypes <sec:abstract-types>
 

--- a/other/preface_revised.typ
+++ b/other/preface_revised.typ
@@ -11,3 +11,7 @@ These standard libraries are now available in the form of a zero-dependency Hask
 
 
 #heading(level: 2, numbering: none)[Changes to the  Report]
+
+#heading(level: 3, numbering: none)[Remove mutually recursive modules]
+
+The requirement to support mutually recursive modules has been lifted.


### PR DESCRIPTION
This removes the requirement to support mutually recursive modules and instead has acyclic modules be the requirement. This is primarily because the report doesn't specify requirements for using mutually recursive modules making them effectively unusable.

This closes #52.